### PR TITLE
Switch from standard deviation to use a confidence interval.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=$CONFIGURATION ../test
   - make
-  - ./ubench_test --max-deviation=100
+  - ./ubench_test --confidence=100

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,4 +41,4 @@ build_script:
   - copy %CONFIGURATION%\ubench_test.exe ubench_test.exe
 
 test_script:
-  - ubench_test.exe --max-deviation=100
+  - ubench_test.exe --confidence=100


### PR DESCRIPTION
Previously I was using a pretty gross hack to cut off low/high outlier
values in the benchmarking algorithm - sort the values and chop off the
top and bottom ones. This isn't statistically sound nor a good idea. The
problem is that standard deviation isn't that useful in of itself for a
data set - it can tell you the spread but not the likelihood of a given
run of the benchmark occuring within a constrained range around the
mean.

Instead with this commit I'm using the confidence interval -
specifically the 99% confidence interval. This means that for any given
result in the set, there is a 99% chance that it will occur within a
range around the mean. So by minimizing the confidence interval instead
of standard deviation we are both excluding the outliers that I hackily
had excluded previously, and giving ourselves a good level of confidence
(har har) that the result is accurate.