### PR TITLE
Add fixtures to ubench.h.

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -40,3 +40,25 @@ UBENCH(c, do_nothing) {
   memcpy(b, a, sizeof(a));
   UBENCH_DO_NOTHING(b);
 }
+
+struct c_my_fixture {
+  char *data;
+};
+
+UBENCH_F_SETUP(c_my_fixture) {
+  const int size = 128 * 1024 * 1024;
+  ubench_fixture->data = (char *)malloc(size);
+  memset(ubench_fixture->data, ' ', size - 2);
+  ubench_fixture->data[size - 1] = '\0';
+  ubench_fixture->data[size / 2] = 'f';
+}
+
+UBENCH_F_TEARDOWN(c_my_fixture) { free(ubench_fixture->data); }
+
+UBENCH_F(c_my_fixture, strchr) {
+  UBENCH_DO_NOTHING(strchr(ubench_fixture->data, 'f'));
+}
+
+UBENCH_F(c_my_fixture, strrchr) {
+  UBENCH_DO_NOTHING(strrchr(ubench_fixture->data, 'f'));
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -40,3 +40,25 @@ UBENCH(cpp, do_nothing) {
   memcpy(b, a, sizeof(a));
   UBENCH_DO_NOTHING(b);
 }
+
+struct cpp_my_fixture {
+  char *data;
+};
+
+UBENCH_F_SETUP(cpp_my_fixture) {
+  const int size = 128 * 1024 * 1024;
+  ubench_fixture->data = static_cast<char *>(malloc(size));
+  memset(ubench_fixture->data, ' ', size - 2);
+  ubench_fixture->data[size - 1] = '\0';
+  ubench_fixture->data[size / 2] = 'f';
+}
+
+UBENCH_F_TEARDOWN(cpp_my_fixture) { free(ubench_fixture->data); }
+
+UBENCH_F(cpp_my_fixture, strchr) {
+  UBENCH_DO_NOTHING(strchr(ubench_fixture->data, 'f'));
+}
+
+UBENCH_F(cpp_my_fixture, strrchr) {
+  UBENCH_DO_NOTHING(strrchr(ubench_fixture->data, 'f'));
+}

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -45,3 +45,25 @@ UBENCH(cpp11, do_nothing) {
   memcpy(b, a, sizeof(a));
   UBENCH_DO_NOTHING(b);
 }
+
+struct cpp11_my_fixture {
+  char *data;
+};
+
+UBENCH_F_SETUP(cpp11_my_fixture) {
+  const int size = 128 * 1024 * 1024;
+  ubench_fixture->data = static_cast<char *>(malloc(size));
+  memset(ubench_fixture->data, ' ', size - 2);
+  ubench_fixture->data[size - 1] = '\0';
+  ubench_fixture->data[size / 2] = 'f';
+}
+
+UBENCH_F_TEARDOWN(cpp11_my_fixture) { free(ubench_fixture->data); }
+
+UBENCH_F(cpp11_my_fixture, strchr) {
+  UBENCH_DO_NOTHING(strchr(ubench_fixture->data, 'f'));
+}
+
+UBENCH_F(cpp11_my_fixture, strrchr) {
+  UBENCH_DO_NOTHING(strrchr(ubench_fixture->data, 'f'));
+}


### PR DESCRIPTION
This commit adds fixtures to ubench.h via a similar mechanism to how they work for utest.h. Fixtures are a great way of initializing data once and then using it in the body of the benchmark - without skewing the data collection of the benchmark with all the initialization code.