### PR TITLE
Added support for initializing benchmark-data in each benchmark via U…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,42 @@ The UBENCH macro takes two parameters - the first being the set that the
 benchmark belongs to, the second being the name of the benchmark. This allows
 benchmarks to be grouped for convenience.
 
+## Define a Benchmark with setup
+
+In some cases it might be beneficial to setup your benchmark state locally in
+your benchmark.
+This can be done like so:
+
+```c
+#include "ubench.h"
+
+UBENCH_EX(foo, short_string) {
+  const char* short_string = alloc_test_string(16);
+
+  UBENCH_DO_BENCHMARK() {
+    to_test(short_string);
+  }
+
+  free(short_string);
+}
+
+UBENCH_EX(foo, long_string) {
+  const char* long_string = alloc_test_string(16 * 1024);
+
+  UBENCH_DO_BENCHMARK() {
+    to_test(long_string);
+  }
+
+  free(long_string);
+}
+```
+The benchmark will keep running and measuring within the {} after UBENCH_DO_BENCHMARK()
+so all code before and after that scope is only executed once.
+This might be the right thing to do in cases where you only want the setup in one benchmark.
+If you want some setup for en entire set a 'fixture' might be a better way to go, maybe
+you need to do some system-setup for each benchmark in a set.
+
+
 ## Define a Fixtured Benchmark
 
 Fixtures are a way to have some state that is initialized once and then used
@@ -145,6 +181,31 @@ UBENCH_F(foo, strrchr) {
 Note that fixtures are not guaranteed to be constructed only once - but they are
 guaranteed to not impede on the collection of accurate metrics for the running
 of your benchmark.
+
+It is also possible to use a fixture in combination with a benchmark with a setup
+as follows:
+
+```c
+UBENCH_EX_F(my_sys, short_string) {
+  const char* short_string = alloc_test_string(16);
+
+  UBENCH_DO_BENCHMARK() {
+    my_sys_work(ubench_fixture->sys, short_string));
+  }
+
+  free(short_string);
+}
+
+UBENCH_EX_F(my_sys, long_string) {
+  const char* long_string = alloc_test_string(16 * 1024);
+
+  UBENCH_DO_BENCHMARK() {
+    my_sys_work(ubench_fixture->sys, long_string));
+  }
+
+  free(long_string);
+}
+```
 
 ## Testing Macros
 

--- a/test/test.c
+++ b/test/test.c
@@ -63,7 +63,7 @@ struct c_my_fixture {
 UBENCH_F_SETUP(c_my_fixture) {
   const int size = 128 * 1024 * 1024;
   ubench_fixture->data = (char *)malloc(size);
-  memset(ubench_fixture->data, ' ', size - 2);
+  memset(ubench_fixture->data, ' ', size - 1);
   ubench_fixture->data[size - 1] = '\0';
   ubench_fixture->data[size / 2] = 'f';
 }

--- a/test/test.c
+++ b/test/test.c
@@ -41,6 +41,20 @@ UBENCH(c, do_nothing) {
   UBENCH_DO_NOTHING(b);
 }
 
+UBENCH_EX(c, ex)
+{
+  int b[1024];
+  int i;
+  int sum;
+  memset(b, 0x0, sizeof(b));
+  
+  UBENCH_BEGIN
+    sum = 0;
+    for(i = 0; i < 1024; ++i)
+      sum += i;
+  UBENCH_END
+}
+
 struct c_my_fixture {
   char *data;
 };
@@ -61,4 +75,15 @@ UBENCH_F(c_my_fixture, strchr) {
 
 UBENCH_F(c_my_fixture, strrchr) {
   UBENCH_DO_NOTHING(strrchr(ubench_fixture->data, 'f'));
+}
+
+UBENCH_EX_F(c_my_fixture, strrchr_ex)
+{
+  char data[128*4];
+  memcpy(data, ubench_fixture->data, sizeof(data));
+  data[sizeof(data)-1] = '\0';
+  
+  UBENCH_BEGIN
+    UBENCH_DO_NOTHING(strchr(data, 'f'));
+  UBENCH_END
 }

--- a/test/test.c
+++ b/test/test.c
@@ -48,7 +48,7 @@ UBENCH_EX(c, ex)
   int sum;
   memset(b, 0x0, sizeof(b));
 
-  UBENCH_KEEP_RUNNING()
+  UBENCH_DO_BENCHMARK()
   {
     sum = 0;
     for(i = 0; i < 1024; ++i)
@@ -84,7 +84,7 @@ UBENCH_EX_F(c_my_fixture, strrchr_ex)
   memcpy(data, ubench_fixture->data, sizeof(data));
   data[sizeof(data)-1] = '\0';
   
-  UBENCH_KEEP_RUNNING()
+  UBENCH_DO_BENCHMARK()
   {
     UBENCH_DO_NOTHING(strchr(data, 'f'));
   }

--- a/test/test.c
+++ b/test/test.c
@@ -47,12 +47,13 @@ UBENCH_EX(c, ex)
   int i;
   int sum;
   memset(b, 0x0, sizeof(b));
-  
-  UBENCH_BEGIN
+
+  UBENCH_KEEP_RUNNING()
+  {
     sum = 0;
     for(i = 0; i < 1024; ++i)
       sum += i;
-  UBENCH_END
+  }
 }
 
 struct c_my_fixture {
@@ -83,7 +84,8 @@ UBENCH_EX_F(c_my_fixture, strrchr_ex)
   memcpy(data, ubench_fixture->data, sizeof(data));
   data[sizeof(data)-1] = '\0';
   
-  UBENCH_BEGIN
+  UBENCH_KEEP_RUNNING()
+  {
     UBENCH_DO_NOTHING(strchr(data, 'f'));
-  UBENCH_END
+  }
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -41,6 +41,20 @@ UBENCH(cpp, do_nothing) {
   UBENCH_DO_NOTHING(b);
 }
 
+UBENCH_EX(cpp, ex)
+{
+  int b[1024];
+  int i;
+  int sum;
+  memset(b, 0x0, sizeof(b));
+  
+  UBENCH_BEGIN
+    sum = 0;
+    for(i = 0; i < 1024; ++i)
+      sum += i;
+  UBENCH_END
+}
+
 struct cpp_my_fixture {
   char *data;
 };
@@ -61,4 +75,15 @@ UBENCH_F(cpp_my_fixture, strchr) {
 
 UBENCH_F(cpp_my_fixture, strrchr) {
   UBENCH_DO_NOTHING(strrchr(ubench_fixture->data, 'f'));
+}
+
+UBENCH_EX_F(cpp_my_fixture, strrchr_ex)
+{
+  char data[128*4];
+  memcpy(data, ubench_fixture->data, sizeof(data));
+  data[sizeof(data)-1] = '\0';
+  
+  UBENCH_BEGIN
+    UBENCH_DO_NOTHING(strchr(data, 'f'));
+  UBENCH_END
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -63,7 +63,7 @@ struct cpp_my_fixture {
 UBENCH_F_SETUP(cpp_my_fixture) {
   const int size = 128 * 1024 * 1024;
   ubench_fixture->data = static_cast<char *>(malloc(size));
-  memset(ubench_fixture->data, ' ', size - 2);
+  memset(ubench_fixture->data, ' ', size - 1);
   ubench_fixture->data[size - 1] = '\0';
   ubench_fixture->data[size / 2] = 'f';
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -48,11 +48,12 @@ UBENCH_EX(cpp, ex)
   int sum;
   memset(b, 0x0, sizeof(b));
   
-  UBENCH_BEGIN
+  UBENCH_KEEP_RUNNING()
+  {
     sum = 0;
     for(i = 0; i < 1024; ++i)
       sum += i;
-  UBENCH_END
+  }
 }
 
 struct cpp_my_fixture {
@@ -83,7 +84,8 @@ UBENCH_EX_F(cpp_my_fixture, strrchr_ex)
   memcpy(data, ubench_fixture->data, sizeof(data));
   data[sizeof(data)-1] = '\0';
   
-  UBENCH_BEGIN
+  UBENCH_KEEP_RUNNING()
+  {
     UBENCH_DO_NOTHING(strchr(data, 'f'));
-  UBENCH_END
+  }
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -48,7 +48,7 @@ UBENCH_EX(cpp, ex)
   int sum;
   memset(b, 0x0, sizeof(b));
   
-  UBENCH_KEEP_RUNNING()
+  UBENCH_DO_BENCHMARK()
   {
     sum = 0;
     for(i = 0; i < 1024; ++i)
@@ -84,7 +84,7 @@ UBENCH_EX_F(cpp_my_fixture, strrchr_ex)
   memcpy(data, ubench_fixture->data, sizeof(data));
   data[sizeof(data)-1] = '\0';
   
-  UBENCH_KEEP_RUNNING()
+  UBENCH_DO_BENCHMARK()
   {
     UBENCH_DO_NOTHING(strchr(data, 'f'));
   }

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -46,6 +46,20 @@ UBENCH(cpp11, do_nothing) {
   UBENCH_DO_NOTHING(b);
 }
 
+UBENCH_EX(cpp11, ex)
+{
+  int b[1024];
+  int i;
+  int sum;
+  memset(b, 0x0, sizeof(b));
+  
+  UBENCH_BEGIN
+    sum = 0;
+    for(i = 0; i < 1024; ++i)
+      sum += i;
+  UBENCH_END
+}
+
 struct cpp11_my_fixture {
   char *data;
 };
@@ -66,4 +80,15 @@ UBENCH_F(cpp11_my_fixture, strchr) {
 
 UBENCH_F(cpp11_my_fixture, strrchr) {
   UBENCH_DO_NOTHING(strrchr(ubench_fixture->data, 'f'));
+}
+
+UBENCH_EX_F(cpp11_my_fixture, strchr_ex)
+{
+  char data[128*4];
+  memcpy(data, ubench_fixture->data, sizeof(data));
+  data[sizeof(data)-1] = '\0';
+  
+  UBENCH_BEGIN
+    UBENCH_DO_NOTHING(strchr(data, 'f'));
+  UBENCH_END
 }

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -68,7 +68,7 @@ struct cpp11_my_fixture {
 UBENCH_F_SETUP(cpp11_my_fixture) {
   const int size = 128 * 1024 * 1024;
   ubench_fixture->data = static_cast<char *>(malloc(size));
-  memset(ubench_fixture->data, ' ', size - 2);
+  memset(ubench_fixture->data, ' ', size - 1);
   ubench_fixture->data[size - 1] = '\0';
   ubench_fixture->data[size / 2] = 'f';
 }

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -53,11 +53,12 @@ UBENCH_EX(cpp11, ex)
   int sum;
   memset(b, 0x0, sizeof(b));
   
-  UBENCH_BEGIN
+  UBENCH_KEEP_RUNNING()
+  {
     sum = 0;
     for(i = 0; i < 1024; ++i)
       sum += i;
-  UBENCH_END
+  }
 }
 
 struct cpp11_my_fixture {
@@ -88,7 +89,8 @@ UBENCH_EX_F(cpp11_my_fixture, strchr_ex)
   memcpy(data, ubench_fixture->data, sizeof(data));
   data[sizeof(data)-1] = '\0';
   
-  UBENCH_BEGIN
+  UBENCH_KEEP_RUNNING()
+  {
     UBENCH_DO_NOTHING(strchr(data, 'f'));
-  UBENCH_END
+  }
 }

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -53,7 +53,7 @@ UBENCH_EX(cpp11, ex)
   int sum;
   memset(b, 0x0, sizeof(b));
   
-  UBENCH_KEEP_RUNNING()
+  UBENCH_DO_BENCHMARK()
   {
     sum = 0;
     for(i = 0; i < 1024; ++i)
@@ -89,7 +89,7 @@ UBENCH_EX_F(cpp11_my_fixture, strchr_ex)
   memcpy(data, ubench_fixture->data, sizeof(data));
   data[sizeof(data)-1] = '\0';
   
-  UBENCH_KEEP_RUNNING()
+  UBENCH_DO_BENCHMARK()
   {
     UBENCH_DO_NOTHING(strchr(data, 'f'));
   }

--- a/ubench.h
+++ b/ubench.h
@@ -307,7 +307,7 @@ UBENCH_EXTERN struct ubench_state_s ubench_state;
 #endif
 
 #define UBENCH_BEGIN                                                             \
-    ubench_int64_t ubench_sample_idx = 0;                                        \
+    ubench_int64_t ubench_sample_idx;                                            \
     for (ubench_sample_idx = 0; ubench_sample_idx < size; ubench_sample_idx++) { \
       ns[ubench_sample_idx] = ubench_ns();
 
@@ -341,7 +341,7 @@ UBENCH_EXTERN struct ubench_state_s ubench_state;
   static void ubench_run_##SET##_##NAME(void);                                 \
   static void ubench_##SET##_##NAME(ubench_int64_t *const ns,                  \
                                     const ubench_int64_t size) {               \
-    ubench_int64_t i = 0;                                                      \
+    ubench_int64_t i;                                                          \
     for (i = 0; i < size; i++) {                                               \
       ns[i] = ubench_ns();                                                     \
       ubench_run_##SET##_##NAME();                                             \
@@ -412,7 +412,7 @@ UBENCH_EXTERN struct ubench_state_s ubench_state;
   static void ubench_run_##FIXTURE##_##NAME(struct FIXTURE *);                 \
   static void ubench_f_##FIXTURE##_##NAME(ubench_int64_t *const ns,            \
                                           const ubench_int64_t size) {         \
-    ubench_int64_t i = 0;                                                      \
+    ubench_int64_t i;                                                          \
     struct FIXTURE fixture;                                                    \
     memset(&fixture, 0, sizeof(fixture));                                      \
     ubench_f_setup_##FIXTURE(&fixture);                                        \

--- a/ubench.h
+++ b/ubench.h
@@ -312,7 +312,7 @@ UBENCH_EXTERN struct ubench_state_s ubench_state;
 #pragma clang diagnostic pop
 #endif
 
-static int ubench_keep_running(struct ubench_run_state_s* ubs)
+UBENCH_UNUSED static int ubench_keep_running(struct ubench_run_state_s* ubs)
 {
   ubench_int64_t curr_sample = ubs->sample++;
   ubs->ns[curr_sample] = ubench_ns();

--- a/ubench.h
+++ b/ubench.h
@@ -612,7 +612,7 @@ int ubench_main(int argc, const char *const argv[]) {
     /* Time once to work out the base number of iterations to use. */
     ubench_state.benchmarks[index].func(&ubs);
 
-    iterations = (100 * 1000 * 1000) / (ns[1] - ns[0]);
+    iterations = (100 * 1000 * 1000) / (ns[1] - ns[0] + 1);
     iterations = iterations < min_iterations ? min_iterations : iterations;
     iterations = iterations > max_iterations ? max_iterations : iterations;
 

--- a/ubench.h
+++ b/ubench.h
@@ -46,6 +46,13 @@
    TODO: add a UBENCH_NOINLINE onto the macro generated functions to fix this.
 */
 #pragma warning(disable : 4711)
+
+/*
+   Disable warning about replacing undefined preprocessor macro '__cplusplus' with
+   0 emitted from microsofts own headers.
+   See: https://developercommunity.visualstudio.com/t/issue-in-corecrth-header-results-in-an-undefined-m/433021
+*/
+#pragma warning(disable : 4711)
 #pragma warning(push, 1)
 #endif
 
@@ -612,7 +619,7 @@ int ubench_main(int argc, const char *const argv[]) {
     /* Time once to work out the base number of iterations to use. */
     ubench_state.benchmarks[index].func(&ubs);
 
-    iterations = (100 * 1000 * 1000) / (ns[1] - ns[0] + 1);
+    iterations = (100 * 1000 * 1000) / ((ns[1] <= ns[0]) ? 1 : ns[1] - ns[0]);
     iterations = iterations < min_iterations ? min_iterations : iterations;
     iterations = iterations > max_iterations ? max_iterations : iterations;
 

--- a/ubench.h
+++ b/ubench.h
@@ -312,7 +312,7 @@ UBENCH_EXTERN struct ubench_state_s ubench_state;
 #pragma clang diagnostic pop
 #endif
 
-UBENCH_UNUSED static int ubench_keep_running(struct ubench_run_state_s* ubs)
+static UBENCH_INLINE int ubench_keep_running(struct ubench_run_state_s* ubs)
 {
   ubench_int64_t curr_sample = ubs->sample++;
   ubs->ns[curr_sample] = ubench_ns();

--- a/ubench.h
+++ b/ubench.h
@@ -53,6 +53,14 @@
    See: https://developercommunity.visualstudio.com/t/issue-in-corecrth-header-results-in-an-undefined-m/433021
 */
 #pragma warning(disable : 4668)
+
+/*
+    Disabled warning about dangerous use of section.
+    section '.CRT$XCU' is reserved for C++ dynamic initialization. Manually 
+    creating the section will interfere with C++ dynamic initialization and may lead to undefined behavior
+*/
+#pragma warning(disable : 5247)
+
 #pragma warning(push, 1)
 #endif
 

--- a/ubench.h
+++ b/ubench.h
@@ -60,6 +60,7 @@
     creating the section will interfere with C++ dynamic initialization and may lead to undefined behavior
 */
 #pragma warning(disable : 5247)
+#pragma warning(disable : 5248)
 
 #pragma warning(push, 1)
 #endif

--- a/ubench.h
+++ b/ubench.h
@@ -319,15 +319,15 @@ UBENCH_EXTERN struct ubench_state_s ubench_state;
 #pragma clang diagnostic pop
 #endif
 
-static UBENCH_INLINE int ubench_keep_running(struct ubench_run_state_s* ubs)
+static UBENCH_INLINE int ubench_do_benchmark(struct ubench_run_state_s* ubs)
 {
   ubench_int64_t curr_sample = ubs->sample++;
   ubs->ns[curr_sample] = ubench_ns();
   return curr_sample < ubs->size ? 1 : 0;
 }
 
-#define UBENCH_KEEP_RUNNING()                                                  \
-  while(ubench_keep_running(ubench_run_state) > 0)
+#define UBENCH_DO_BENCHMARK()                                                  \
+  while(ubench_do_benchmark(ubench_run_state) > 0)
 
 #define UBENCH_EX(SET, NAME)                                                   \
   UBENCH_EXTERN struct ubench_state_s ubench_state;                            \
@@ -351,7 +351,7 @@ static UBENCH_INLINE int ubench_keep_running(struct ubench_run_state_s* ubs)
 #define UBENCH(SET, NAME)                                                      \
   static void ubench_run_##SET##_##NAME(void);                                 \
   UBENCH_EX(SET, NAME) {                                                       \
-    UBENCH_KEEP_RUNNING() {                                                    \
+    UBENCH_DO_BENCHMARK() {                                                    \
       ubench_run_##SET##_##NAME();                                             \
     }                                                                          \
   }                                                                            \
@@ -396,7 +396,7 @@ static UBENCH_INLINE int ubench_keep_running(struct ubench_run_state_s* ubs)
 #define UBENCH_F(FIXTURE, NAME)                                                \
   static void ubench_run_##FIXTURE##_##NAME(struct FIXTURE *);                 \
   UBENCH_EX_F(FIXTURE, NAME) {                                                 \
-    UBENCH_KEEP_RUNNING() {                                                    \
+    UBENCH_DO_BENCHMARK() {                                                    \
        ubench_run_##FIXTURE##_##NAME(ubench_fixture);                          \
      }                                                                         \
   }                                                                            \

--- a/ubench.h
+++ b/ubench.h
@@ -52,7 +52,7 @@
    0 emitted from microsofts own headers.
    See: https://developercommunity.visualstudio.com/t/issue-in-corecrth-header-results-in-an-undefined-m/433021
 */
-#pragma warning(disable : 4711)
+#pragma warning(disable : 4668)
 #pragma warning(push, 1)
 #endif
 

--- a/ubench.h
+++ b/ubench.h
@@ -59,8 +59,12 @@
     section '.CRT$XCU' is reserved for C++ dynamic initialization. Manually 
     creating the section will interfere with C++ dynamic initialization and may lead to undefined behavior
 */
+#if defined(_MSC_FULL_VER)
+#if _MSC_FULL_VER >= 192930100 // this warning was introduced in Visual Studio 2019 version 16.11
 #pragma warning(disable : 5247)
 #pragma warning(disable : 5248)
+#endif
+#endif
 
 #pragma warning(push, 1)
 #endif

--- a/ubench.h
+++ b/ubench.h
@@ -363,7 +363,6 @@ UBENCH_UNUSED static int ubench_keep_running(struct ubench_run_state_s* ubs)
   static void ubench_run_ex_##FIXTURE##_##NAME(struct FIXTURE *,               \
                                             struct ubench_run_state_s*);       \
   static void ubench_f_##FIXTURE##_##NAME(struct ubench_run_state_s* ubench_run_state) { \
-    ubench_int64_t i;                                                          \
     struct FIXTURE fixture;                                                    \
     memset(&fixture, 0, sizeof(fixture));                                      \
     ubench_f_setup_##FIXTURE(&fixture);                                        \


### PR DESCRIPTION
ubench.h has no good way to setup benchmark data in the benchmarks.

First of all, thanks for providing a benchmark-lib that is not the behemoth that google_benchmark is :)

I thought I was going to try it out in my own code but ended up with a problem, there is no real good way of initializing bench-data for each benchmark.
I was working to port these benchmarks https://github.com/wc-duck/datalibrary/blob/master/benchmark/dlbench.cpp where each benchmark need to setup some data to bench.

I tried to use fixtures but that ended up quite cumbersome and not really what fixtures are all about. It would force me to add a fixture-struct, UBENCH_F_SETUP() and UBENCH_F_TEARDOWN() for each benchmark, + there is no real way in this case to have benchmark-suites.

It would end up something like this

```c
struct benching_floats
{
    // ... some data ...
};

UBENCH_F_SETUP(benching_floats)
{
    // ... setup the data ...
}

UBENCH_F_TEARDOWN(benching_floats)
{
    // ... setup the data ...
}

UBENCH_F(benching_floats, bench) // ... just calling it "bench"... don't really know what else to do.
{
    // ... run the benchmarks ...
}

struct benching_ints
{
    // ... some data ...
};

UBENCH_F_SETUP(benching_ints)
{
    // ... setup the data ...
}

UBENCH_F_TEARDOWN(benching_ints)
{
    // ... setup the data ...
}

UBENCH_F(benching_ints, bench)
{
    // ... run the benchmarks ...
}
```

In google_benchmark you can write your data-setup in your actual benchmarks.
I took the liberty to implement a proof-of-concept of how that could work in UBENCH that would support code like this:

```c
UBENCH_EX(benching, floats)
{
    // ... setup the data ...

    UBENCH_BEGIN
        // ... benchmark code goes here ...
    UBENCH_END

    // ... teardown the data if needed ...
}

UBENCH_EX(benching, ints)
{
    // ... setup the data ...

    UBENCH_BEGIN
        // ... benchmark code goes here ...
    UBENCH_END

    // ... teardown the data if needed ...
}
```

or with fixtures

```c
struct benching
{
    // ... some data ...
};

UBENCH_F_SETUP(benching)
{
    // ... setup the data ...
}

UBENCH_F_TEARDOWN(benching)
{
    // ... setup the data ...
}

UBENCH_EX_F(benching, floats)
{
    // ... setup the data, maybe use ubench_fixture? ...

    UBENCH_BEGIN
        // ... benchmark code goes here ...
    UBENCH_END

    // ... teardown the data if needed ...
}

UBENCH_EX_F(benching, ints)
{
    // ... setup the data, maybe use ubench_fixture? ...

    UBENCH_BEGIN
        // ... benchmark code goes here ...
    UBENCH_END

    // ... teardown the data if needed ...
}
```

Now I wouldn't expect this to get merged as is (or even at all), but I think it would be worth thinking about and a proof-of-concept makes that easier :)

There are some caveats with proposed solution here

1) the names with _EX_ really isn't that nice imho but I couldn't think of any better name.
2) the iterator 'ubench_int64_t i = 0;' in UBENCH_BEGIN is not guaranteed to be in the beginning of the function. That might be a problem if you want to support really old C.
3) maybe others, I might have missed something fundemental that just makes this a bad idea?