### PR TITLE
Remove unnecessary semicolon from `README.md` quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ to ensure some meaningful confidence interval can be computed.
 In one C or C++ file, you must call the macro UBENCH_MAIN:
 
 ```c
-UBENCH_MAIN();
+UBENCH_MAIN()
 ```
 
 This will call into ubench.h, instantiate all the benchmarks and run the


### PR DESCRIPTION
Hi @sheredom ,

Thanks for all your great libraries, including ubench.h!

Noticed one tiny detail which could be corrected in the README.md to make getting started a smooth. The additional semicolon does not get along well with `-Werror,-Wextra-semi`.
