### PR TITLE
fix: include <time.h> on FreeBSD

### DIFF
--- a/ubench.h
+++ b/ubench.h
@@ -146,7 +146,7 @@ UBENCH_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
 #endif
 #endif
 
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
 #include <time.h>
 #endif
 


### PR DESCRIPTION
FreeBSD has `timespec_get()` and `TIME_UTC` in `<time.h>` as defined in the C11 standard.